### PR TITLE
Using word that is word is bad description

### DIFF
--- a/tools/graphql-tools/generate-schema.md
+++ b/tools/graphql-tools/generate-schema.md
@@ -50,7 +50,7 @@ schema {
 `;
 ```
 
-Then you define resolvers as a nested object that maps type and field names to resolver functions:
+Then you define resolvers that map schema to connectors' results or in this instance redacted sample json intefaced with lodash methods.
 
 ```js
 const resolveFunctions = {


### PR DESCRIPTION
I suspect that sentence doesn't make sense altogether. I can't speculate how schema syntax for mutation is pertinent to what happens in resolvers, but describing how resolver is called for would be cool.