### PR TITLE
Add field resolver example other than RootQuery fields.

### DIFF
--- a/tools/graphql-tools/generate-schema.md
+++ b/tools/graphql-tools/generate-schema.md
@@ -32,6 +32,7 @@ type Post {
 # the schema allows the following query:
 type Query {
   posts: [Post]
+  author(id: Int!): Author # author query must receive an id as argument
 }
 
 # this schema allows the following mutation:
@@ -216,7 +217,7 @@ GraphiQL has built-in support for displaying docstrings with markdown syntax. Yo
 type MyObjectType {
   # Description for field
   myField: String!
-  
+
   otherField(
     # Description for argument
     arg: Int

--- a/tools/graphql-tools/generate-schema.md
+++ b/tools/graphql-tools/generate-schema.md
@@ -25,8 +25,8 @@ type Author {
 type Post {
   id: Int!
   title: String
-  author: Author
   votes: Int
+  author: Author
 }
 
 # the schema allows the following query:

--- a/tools/graphql-tools/resolvers.md
+++ b/tools/graphql-tools/resolvers.md
@@ -16,7 +16,12 @@ The `resolverMap` object should have a map of resolvers for each relevant GraphQ
 const resolverMap = {
   Query: {
     author(obj, args, context, info) {
-      return Authors.find({ name: args.name });
+      return find(authors, { id: args.id });
+    },
+  },
+  Author: {
+    posts(author) {
+      return filter(posts, { authorId: author.id });
     },
   },
 };


### PR DESCRIPTION
Even though the [Generatin a schema](http://dev.apollodata.com/tools/graphql-tools/generate-schema.html) page covers it a bit, there is no mentioning of the possibility of field resolver on types other than the RootQuery.