### PR TITLE
Add basic ES6 Import syntax directions

### DIFF
--- a/tools/graphql-server/setup.md
+++ b/tools/graphql-server/setup.md
@@ -50,6 +50,10 @@ graphqlExpress(request => ({
 
 This is useful if you need to attach objects to your context on a per-request basis, for example to initialize user data, caching tools like `dataloader`, or set up some API keys.
 
+<h2 id="importingESModules">Importing ES6 Modules</h2>
+
+Currently, the ES6 Module import syntax used in these exampels is not implemented in Nodejs 6.x,7.x, and earlier versions.  To use these examples, you will need to configure an external tool like [Babel](https://babeljs.io/) that will transpile the import statements into standard require statements.  For example, ```import express from 'express';``` would become  ```var express = require('express');```.  If you don't want to use an external transpiler, you can manually convert the imports to requires using the example format.     
+
 <h2 id="graphqlExpress">Using with Express</h2>
 
 The following code snippet shows how to use GraphQL Server with Express:


### PR DESCRIPTION
Many developers will want to try GraphQL, but aren't NodeJS/JS developers.  Using syntax that requires external tools without any reference to the required tool is very frustrating.  This small addition, should help developers new to the JS ecosystem get started in the right direction when trying to use the examples.