### PR TITLE
Add missing example data to generate-schema documentation 

### DIFF
--- a/tools/graphql-tools/generate-schema.md
+++ b/tools/graphql-tools/generate-schema.md
@@ -48,6 +48,19 @@ Then you define resolvers as a nested object that maps type and field names to r
 ```js
 import { find, filter } from 'lodash';
 
+// example data
+const authors = [
+  { id: 1, firstName: 'Tom', lastName: 'Coleman' },
+  { id: 2, firstName: 'Sashko', lastName: 'Stubailo' },
+  { id: 3, firstName: 'Mikhail', lastName: 'Novikov' },
+];
+const posts = [
+  { id: 1, authorId: 1, title: 'Introduction to GraphQL', votes: 2 },
+  { id: 2, authorId: 2, title: 'Welcome to Meteor', votes: 3 },
+  { id: 3, authorId: 2, title: 'Advanced GraphQL', votes: 1 },
+  { id: 4, authorId: 3, title: 'Launchpad is Cool', votes: 7 },
+];
+
 const resolvers = {
   Query: {
     posts: () => posts,


### PR DESCRIPTION
The generate-schema examples uses `posts` and `authors` without defining them.
Copied/pasted them in from the fantastic launchpad link.