### PR TITLE
Please include complete server-side setup code...

### DIFF
--- a/tools/graphql-subscriptions/setup.md
+++ b/tools/graphql-subscriptions/setup.md
@@ -99,7 +99,7 @@ ws.listen(PORT, () => {
 
 ```
 
-See [the Laddad demo app for complete working sample code](https://dev-blog.apollodata.com/tutorial-graphql-subscriptions-server-side-e51c32dc2951).
+See [the tutorial on Medium for complete working sample code](https://dev-blog.apollodata.com/tutorial-graphql-subscriptions-server-side-e51c32dc2951).
 
 <h2 id="subscription-resolver">Subscription Resolver</h2>
 


### PR DESCRIPTION
...including setup for queries *and* subscriptions. Note that the current server-side setup code for queries, at http://dev.apollodata.com/tools/graphql-server/setup.html#graphqlExpress, uses a *different port* (3000) than the code on the current version of this page (4000).  This is potentially confusing,  and can easily make it appear that you need two different  ports, one for queries and one for subscriptions.  In order to avoid this, it is very helpful to include complete setup code, including both queries and subscriptions, on this page. I hope this proposed change may be helpful.