### PR TITLE
Fixed the name of the Meteor Package

### DIFF
--- a/tools/graphql-subscriptions/meteor.md
+++ b/tools/graphql-subscriptions/meteor.md
@@ -3,7 +3,7 @@ title: Meteor
 order: 407
 ---
 
-Meteor exposes `httpServer` server over a `meteor/webapp` package, so you can use it the same way as any other http server:
+Meteor exposes `httpServer` server through the `meteor/webapp` package, so you can use it the same way as any other http server:
 
 ```js
 import { WebApp } from 'meteor/webapp';

--- a/tools/graphql-subscriptions/meteor.md
+++ b/tools/graphql-subscriptions/meteor.md
@@ -3,7 +3,7 @@ title: Meteor
 order: 407
 ---
 
-Meteor exposes `httpServer` server over a `meteor/web` package, so you can use it the same way as any other http server:
+Meteor exposes `httpServer` server over a `meteor/webapp` package, so you can use it the same way as any other http server:
 
 ```js
 import { WebApp } from 'meteor/webapp';


### PR DESCRIPTION
I noticed that the package was called meteor/web when the import is meteor/webapp. To me, this adds clarity.