### PR TITLE
typeResolvers should be passed to makeExecutableSchema in mocking.md

### DIFF
--- a/tools/graphql-tools/mocking.md
+++ b/tools/graphql-tools/mocking.md
@@ -186,7 +186,8 @@ const typeResolvers = {
 }
 
 const schema = makeExecutableSchema({
-  typeDefs
+  typeDefs,
+  typeResolvers
 })
 
 addMockFunctionsToSchema({


### PR DESCRIPTION
Currently the `typeResolvers` aren't used at all in the example, while they should be passed to `makeExecutableSchema` as seen in https://github.com/apollographql/graphql-tools/blob/5c5418cec88f1d5520eccc1d2e6dfaa511547e4d/src/schemaGenerator.ts#L99